### PR TITLE
Add support for `allowInsecureRequests`

### DIFF
--- a/api/src/openid-client-wrapper.js
+++ b/api/src/openid-client-wrapper.js
@@ -5,6 +5,7 @@ const {
   calculatePKCECodeChallenge,
   buildAuthorizationUrl,
   authorizationCodeGrant,
+  allowInsecureRequests,
 } = require('openid-client');
 
 module.exports = {
@@ -13,4 +14,5 @@ module.exports = {
   calculatePKCECodeChallenge,
   buildAuthorizationUrl,
   authorizationCodeGrant,
+  allowInsecureRequests,
 };

--- a/api/src/services/sso-login.js
+++ b/api/src/services/sso-login.js
@@ -82,7 +82,7 @@ const oidcServerSConfig = async () => {
 const getAuthorizationUrl = async (redirectUrl) => {
   const params = {
     redirect_uri: redirectUrl,
-    scope: 'openid email'
+    scope: 'openid'
   };
 
   try {


### PR DESCRIPTION
# Description

Adds support for connecting to an OIDC provider via `HTTP` (instead of `HTTPS`).  `"allow_insecure_requests": true` must be set in the  `oidc_provider` settings.

This code is flowing successfully for me against a local Keycloak instance hosted at `http://localhost:8080` (with no certs set).

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

